### PR TITLE
Implement a windows listener using named pipes.

### DIFF
--- a/network/README.md
+++ b/network/README.md
@@ -8,7 +8,7 @@ This library is designed to be integrated in your program.
 
 1. Implement the `network.Driver` interface.
 2. Initialize a `network.Handler` with your implementation.
-3. Call either `ServeTCP` or `ServeUnix` from the `network.Handler`.
+3. Call either `ServeTCP`, `ServeUnix` or `ServeWindows` from the `network.Handler`.
 
 ### Example using TCP sockets:
 
@@ -28,6 +28,26 @@ This library is designed to be integrated in your program.
   d := MyNetworkDriver{}
   h := network.NewHandler(d)
   h.ServeUnix("root", "test_network")
+```
+
+### Example using Windows named pipes:
+
+```go
+import "github.com/docker/go-plugins-helpers/network"
+import "github.com/docker/go-plugins-helpers/sdk"
+
+d := MyNetworkDriver{}
+h := network.NewHandler(d)
+
+config := sdk.WindowsPipeConfig{
+  // open, read, write permissions for everyone 
+  // (uses Windows Security Descriptor Definition Language)
+  SecurityDescriptor: "S:(ML;;NW;;;LW)D:(A;;0x12019f;;;WD)",
+  InBufferSize:       4096,
+  OutBufferSize:      4096,
+}
+
+h.ServeWindows("//./pipe/testpipe", "test_network", &config)
 ```
 
 ## Full example plugins

--- a/sdk/spec_file_generator.go
+++ b/sdk/spec_file_generator.go
@@ -1,0 +1,37 @@
+package sdk
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+type protocol string
+
+const (
+	protoTCP       protocol = "tcp"
+	protoNamedPipe protocol = "npipe"
+)
+
+func writeSpec(name, address string, proto protocol) (string, error) {
+
+	var pluginSpecDir string
+	if runtime.GOOS == "windows" {
+		pluginSpecDir = ([]string{filepath.Join(os.Getenv("programdata"), "docker", "plugins")})[0]
+	} else {
+		pluginSpecDir = "/etc/docker/plugins"
+	}
+
+	if err := os.MkdirAll(pluginSpecDir, 0755); err != nil {
+		return "", err
+	}
+	spec := filepath.Join(pluginSpecDir, name+".spec")
+
+	url := string(proto) + "://" + address
+	if err := ioutil.WriteFile(spec, []byte(url), 0644); err != nil {
+		return "", err
+	}
+
+	return spec, nil
+}

--- a/sdk/unix_listener_unsupported.go
+++ b/sdk/unix_listener_unsupported.go
@@ -8,9 +8,11 @@ import (
 )
 
 var (
-	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on linux and freebsd")
+	errOnlySupportedOnLinuxAndFreeBSD = errors.New("unix socket creation is only supported on Linux and FreeBSD")
 )
 
-func newUnixListener(pluginName string, group string) (net.Listener, string, error) {
-	return nil, "", errOnlySupportedOnLinuxAndFreeBSD
+func newUnixListener(pluginName string, group string) func() (net.Listener, string, string, error) {
+	return func() (net.Listener, string, string, error) {
+		return nil, "", "", errOnlySupportedOnLinuxAndFreeBSD
+	}
 }

--- a/sdk/windows_listener.go
+++ b/sdk/windows_listener.go
@@ -1,0 +1,29 @@
+// +build windows
+
+package sdk
+
+import (
+	"net"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) func() (net.Listener, string, string, error) {
+	return func() (net.Listener, string, string, error) {
+		winioPipeConfig := winio.PipeConfig{
+			SecurityDescriptor: pipeConfig.SecurityDescriptor,
+			MessageMode:        true,
+			InputBufferSize:    pipeConfig.InBufferSize,
+			OutputBufferSize:   pipeConfig.OutBufferSize,
+		}
+		listener, err := winio.ListenPipe(address, &winioPipeConfig)
+		if err != nil {
+			return nil, "", "", err
+		}
+		spec, err := writeSpec(pluginName, listener.Addr().String(), protoNamedPipe)
+		if err != nil {
+			return nil, "", "", err
+		}
+		return listener, address, spec, nil
+	}
+}

--- a/sdk/windows_listener_unsupported.go
+++ b/sdk/windows_listener_unsupported.go
@@ -1,0 +1,18 @@
+// +build !windows
+
+package sdk
+
+import (
+	"errors"
+	"net"
+)
+
+var (
+	errOnlySupportedOnWindows = errors.New("named pipe creation is only supported on Windows")
+)
+
+func newWindowsListener(address, pluginName string, pipeConfig *WindowsPipeConfig) func() (net.Listener, string, string, error) {
+	return func() (net.Listener, string, string, error) {
+		return nil, "", "", errOnlySupportedOnWindows
+	}
+}

--- a/sdk/windows_pipe_config.go
+++ b/sdk/windows_pipe_config.go
@@ -1,0 +1,13 @@
+package sdk
+
+// WindowsPipeConfig is a helper structure for configuring named pipe parameters on Windows.
+type WindowsPipeConfig struct {
+	// SecurityDescriptor contains a Windows security descriptor in SDDL format.
+	SecurityDescriptor string
+
+	// InBufferSize in bytes.
+	InBufferSize int32
+
+	// OutBufferSize in bytes.
+	OutBufferSize int32
+}


### PR DESCRIPTION
This lets us implement remote drivers on Windows that use named pipes for docker daemon - driver communication.
This change requires that my pull request to go-connections is accepted first (it introduces named pipe socket creation).

Signed-off-by: Michal Kostrzewa <kostrzewa.michal@o2.pl>